### PR TITLE
SDSTOR-11603 :  Fix shared_mutex for multi threads

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -5,7 +5,7 @@ from conans import CMake
 
 class IOMgrConan(ConanFile):
     name = "iomgr"
-    version = "9.2.3"
+    version = "9.2.4"
     homepage = "https://github.com/eBay/IOManager"
     description = "Asynchronous event manager"
     topics = ("ebay", "nublox", "aio")

--- a/src/.clang-format
+++ b/src/.clang-format
@@ -18,7 +18,6 @@ AlignOperands:   false
 AlignTrailingComments: true
 AllowShortBlocksOnASingleLine: true
 AllowShortIfStatementsOnASingleLine: true
-AllowShortBlocksOnASingleLine: true
 AllowShortCaseLabelsOnASingleLine: false
 # AllowShortFunctionsOnASingleLine: InlineOnly
 # AllowShortLoopsOnASingleLine: false

--- a/src/lib/reactor/fiber_lib_boost.cpp
+++ b/src/lib/reactor/fiber_lib_boost.cpp
@@ -66,8 +66,10 @@ void FiberManagerLib::shared_mutex::lock() {
         } else {
             // Owned by the writer or reader, add ourselves to writer queue
             if (s_writer_priority) {
-                ++m_write_waiters;
-                am_i_write_waiter = true;
+                if (!am_i_write_waiter) {
+                    ++m_write_waiters;
+                    am_i_write_waiter = true;
+                }
                 LOGTRACEMOD(iomgr, "[Writer Lock for ctx={}]: Queued, owned by owner={} num_readers={}",
                             (void*)active_ctx, (void*)m_write_owner, m_readers);
             }

--- a/src/test/test_fiber_shared_mutex.cpp
+++ b/src/test/test_fiber_shared_mutex.cpp
@@ -29,9 +29,9 @@ SISL_LOGGING_INIT(IOMGR_LOG_MODS, flip)
 
 SISL_OPTION_GROUP(test_fiber_shared_mutex,
                   (num_threads, "", "num_threads", "number of threads",
-                   ::cxxopts::value< uint32_t >()->default_value("2"), "number"),
+                   ::cxxopts::value< uint32_t >()->default_value("10"), "number"),
                   (num_fibers, "", "num_fibers", "number of fibers per thread",
-                   ::cxxopts::value< uint32_t >()->default_value("8"), "number"),
+                   ::cxxopts::value< uint32_t >()->default_value("20"), "number"),
                   (num_iters, "", "num_iters", "number of iterations",
                    ::cxxopts::value< uint64_t >()->default_value("10000"), "number"),
                   (spdk, "", "spdk", "spdk", ::cxxopts::value< bool >()->default_value("false"), "true or false"));


### PR DESCRIPTION
Make a writer fiber increase `m_write_waiters` only once even after multiple failure attempts of acquiring a lock when awakening.