### PR TITLE
bump cpr to 1.10.5

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -5,7 +5,7 @@ from conans import CMake
 
 class IOMgrConan(ConanFile):
     name = "iomgr"
-    version = "10.0.3"
+    version = "10.0.4"
     homepage = "https://github.com/eBay/IOManager"
     description = "Asynchronous event manager"
     topics = ("ebay", "nublox", "aio")
@@ -50,7 +50,7 @@ class IOMgrConan(ConanFile):
 
     def build_requirements(self):
         self.build_requires("gtest/1.14.0")
-        self.build_requires("cpr/1.10.4")
+        self.build_requires("cpr/1.10.5")
 
     def requirements(self):
         self.requires("sisl/[~=10, include_prerelease=True]@oss/master")


### PR DESCRIPTION
this PR is to resolve the following ERROR:

ERROR: Conflict in cpr/1.10.4:
    'cpr/1.10.4' requires 'libcurl/8.2.1' while 'prometheus-cpp/1.1.0' requires 'libcurl/8.4.0'.
    To fix this conflict you need to override the package 'libcurl' in your root package.
    
<img width="887" alt="Screenshot 2023-11-18 at 20 49 04" src="https://github.com/eBay/IOManager/assets/80438902/eddadc60-73ab-446c-9a4a-904535eb0eb0">

