### PR TITLE
fix-free-issue

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -5,7 +5,7 @@ from conans import CMake
 
 class IOMgrConan(ConanFile):
     name = "iomgr"
-    version = "10.0.6"
+    version = "10.0.7"
     homepage = "https://github.com/eBay/IOManager"
     description = "Asynchronous event manager"
     topics = ("ebay", "nublox", "aio")

--- a/src/lib/iomgr_helper.hpp
+++ b/src/lib/iomgr_helper.hpp
@@ -49,7 +49,7 @@ static bool check_uring_capability(bool& new_interface_supported) {
             }
         }
 
-        free(probe);
+        io_uring_free_probe(probe);
     }
 
 exit:


### PR DESCRIPTION
we should use `io_uring_free_probe` to free the probe allocated by `io_uring_get_probe`, instead of the primitive syscall `free`.

please referring to this page: https://man7.org/linux/man-pages/man3/io_uring_get_probe.3.html