### PR TITLE
unblock real drive testing with hdd

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -6,7 +6,7 @@ import json
 
 class IOMgrConan(ConanFile):
     name = "iomgr"
-    version = "11.3.1"
+    version = "11.3.2"
 
     homepage = "https://github.com/eBay/IOManager"
     description = "Asynchronous event manager"

--- a/src/lib/interfaces/drive_interface.cpp
+++ b/src/lib/interfaces/drive_interface.cpp
@@ -433,7 +433,7 @@ std::error_code KernelDriveInterface::sync_write(IODevice* iodev, const char* da
         ++resubmit_cnt;
     }
     if (sisl_unlikely(written_size != size)) {
-        LOGWARN("Error during write offset={} write_size={} written_size={} errno={} fd={}", offset, size, written_size,
+        LOGWARN("Error during write offset={} size={} written_size={} errno={} fd={}", offset, size, written_size,
                 errno, iodev->fd());
         return std::error_code{((errno == 0) ? ERANGE : errno), std::generic_category()};
     } else {

--- a/src/lib/interfaces/drive_interface.cpp
+++ b/src/lib/interfaces/drive_interface.cpp
@@ -178,6 +178,7 @@ static std::string get_raid_hdd_vendor_model_megcli() {
 #endif
 
 static std::string get_raid_hdd_vendor_model() {
+    return ""; // see this issue for more details: https://github.com/eBay/IOManager/issues/82
 #ifdef MEGACLI_OPTION_ENABLED
     return get_raid_hdd_vendor_model_megcli();
 #else
@@ -216,7 +217,7 @@ drive_type DriveInterface::get_drive_type(const std::string& dev_name) {
         dtype = it->second;
     } else {
         dtype = detect_drive_type(dev_name);
-        LOGINFOMOD(iomgr, "Drive={} is detected to be drive_type={}", dev_name, dtype);
+        LOGINFO("Drive={} is detected to be drive_type={}", dev_name, dtype);
         s_dev_type.insert({dev_name, dtype});
     }
 


### PR DESCRIPTION
This is to unblock testing with hdd drives. 
Opened this issue for tracking when tess team is able to export new sys env as was done for 1.3 release for new HDD vendor currently bounded with NuObject V2
https://github.com/eBay/IOManager/issues/82


This PR already verified with replication long running on 30-18