### PR TITLE
fix detect drive type

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -6,7 +6,7 @@ import json
 
 class IOMgrConan(ConanFile):
     name = "iomgr"
-    version = "11.3.2"
+    version = "11.3.3"
 
     homepage = "https://github.com/eBay/IOManager"
     description = "Asynchronous event manager"

--- a/src/lib/interfaces/drive_interface.cpp
+++ b/src/lib/interfaces/drive_interface.cpp
@@ -200,7 +200,7 @@ static std::string get_raid_hdd_vendor_model() {
 
 drive_type DriveInterface::detect_drive_type(const std::string& dev_name) {
     if (std::filesystem::is_regular_file(std::filesystem::status(dev_name))) {
-        auto device = std::filesystem::path(get_mounted_device(dev_name)).filename();
+        auto device = get_mounted_device(dev_name);
         return is_rotational_device(device) ? drive_type::file_on_hdd : drive_type::file_on_nvme;
     } else if (std::filesystem::is_block_file(std::filesystem::status(dev_name))) {
         return is_rotational_device(dev_name) ? drive_type::block_hdd : drive_type::block_nvme;


### PR DESCRIPTION
in the current code, we use the filename (not the Absolute Path) of the device to get the major and minor number.
while if a physical device is a lvm(logic volume), it will fail to get the major and minor number.
```
NAME              MAJ:MIN RM  SIZE RO TYPE MOUNTPOINTS
vda               252:0    0  100G  0 disk
├─vda1            252:1    0    1M  0 part
├─vda2            252:2    0  488M  0 part /boot
└─vda3            252:3    0 99.5G  0 part
  └─atomicos-root 253:0    0 99.5G  0 lvm  /var/lib/containers/storage/overlay
                                           /sysroot/ostree/deploy/ubuntu-atomic-host/var/tmp
                                           /var/tmp
                                           /var
                                           /usr
                                           /
                                           /sysroot
vdb               252:16   0   64M  0 disk

# ls -rlt /tmp
lrwxrwxrwx 2 root root 11 Jun 18  2023 /tmp -> sysroot/tmp

#df -h /tmp
Filesystem                 Size  Used Avail Use% Mounted on
/dev/mapper/atomicos-root  100G   56G   44G  57% /sysroot
```
this is the info got from `lsblk` in virtual machine, which is my local debug machine.  we can see `atomicos-root` is a lvm device. and /tmp resides in /dev/mapper/atomicos-root


when we run homestore test and create file under /tmp as a device, we can get the following debug info 
```
(gdb) s
iomgr::is_rotational_device (device="atomicos-root") at /var/home/ubuntu/.conan/data/iomgr/11.3.2-35/oss/master/build/8f6113204e39cf5069af1f6032b873fa6df4d478/src/lib/interfaces/drive_interface.cpp:86
86      static bool is_rotational_device(const std::string& device) {
(gdb) n
87          int is_rotational = 0;
(gdb) n
88          const auto maj_min{get_major_minor(device)};
(gdb) p get_major_minor(device)
[06/03/24 01:04:52-07:00] [error] [test_journal_vdev] [762257] [drive_interface.cpp:80:get_major_minor] Unable to stat the path atomicos-root, ignoring to get major/minor, ret:-1
$21 = ""
``` 
so we can see if we use the only file name to get the major/minor of a device, we will get an error.

```
(gdb) p device
$24 = "/dev/mapper/atomicos-root"
(gdb) p get_major_minor(device)
$25 = "253:0"
```
we can see if we use the Absolute Path to get the major/minor, it works.

this is what this PR do


