### PR TITLE
Refresh v8

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -5,7 +5,7 @@ from conans import CMake
 
 class IOMgrConan(ConanFile):
     name = "iomgr"
-    version = "8.7.8"
+    version = "8.7.9"
     homepage = "https://github.com/eBay/IOManager"
     description = "Asynchronous event manager"
     topics = ("ebay", "nublox", "aio")
@@ -59,11 +59,8 @@ class IOMgrConan(ConanFile):
         self.requires("libevent/2.1.12")
         self.requires("spdk/21.07.y")
         self.requires("pistache/0.0.5")
-        self.requires("zmarok-semver/1.1.0")
 
-        self.requires("flatbuffers/1.12.0", override=True)
-        self.requires("openssl/1.1.1q", override=True)
-        self.requires("zlib/1.2.12", override=True)
+        self.requires("openssl/1.1.1s",     override=True)
 
     def build(self):
         cmake = CMake(self)


### PR DESCRIPTION
Mainly to remove the extra dependency on openssl 1.1.1q when it's overridden already to .1s in Sisl.