### PR TITLE
use ninja 1.12.1 to work around 1.11.1 issue

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -9,7 +9,7 @@ required_conan_version = ">=1.60.0"
 
 class IOMgrConan(ConanFile):
     name = "iomgr"
-    version = "11.3.12"
+    version = "11.3.13"
 
     homepage = "https://github.com/eBay/IOManager"
     description = "Asynchronous event manager"
@@ -73,6 +73,7 @@ class IOMgrConan(ConanFile):
         self.requires("libcurl/8.4.0", override=True)
         self.requires("lz4/1.9.4", override=True)
         self.requires("zstd/1.5.5", override=True)
+        self.requires("ninja/1.12.1", override=True)
 
         # ARM needs unreleased versionof libunwind
         if not self.settings.arch in ['x86', 'x86_64']:


### PR DESCRIPTION
https://github.com/scikit-build/ninja-python-distributions/issues/157

12:18:50  pistache 0.0.5
12:18:50
12:18:50    User defined options
12:18:50      Native files: /home/jenkins/.conan2/p/b/pistad34507cfa27c1/b/build-debug/conan/conan_meson_native.ini
12:18:50      prefix      : /
12:18:50
12:18:50
12:18:50  ERROR: Could not detect Ninja v1.8.2 or newer

We hit above issue during rebuilding pistache for both 0.0.5 and 0.0.5.1. Searched around seems due to the python packaging has issues.