### PR TITLE
Implementing device level IO metrics.

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -9,7 +9,7 @@ required_conan_version = ">=1.60.0"
 
 class IOMgrConan(ConanFile):
     name = "iomgr"
-    version = "11.3.12"
+    version = "11.4.0"
 
     homepage = "https://github.com/eBay/IOManager"
     description = "Asynchronous event manager"

--- a/src/include/iomgr/io_device.hpp
+++ b/src/include/iomgr/io_device.hpp
@@ -102,17 +102,17 @@ public:
         case DriveOpType::WRITE:
             HISTOGRAM_OBSERVE(*m_metrics, write_lat, dur);
             HISTOGRAM_OBSERVE(*m_metrics, write_size, iocb->size);
-            LOGINFO("write, size {}, lat {}", iocb->size, dur);
+            LOGTRACE("write, size {}, lat {}", iocb->size, dur);
             break;
         case DriveOpType::READ:
             HISTOGRAM_OBSERVE(*m_metrics, read_lat, dur);
             HISTOGRAM_OBSERVE(*m_metrics, read_size, iocb->size);
-            LOGINFO("read, size {}, lat {}", iocb->size, dur);
+            LOGTRACE("read, size {}, lat {}", iocb->size, dur);
             break;
         case DriveOpType::FSYNC:
             HISTOGRAM_OBSERVE(*m_metrics, fsync_lat, dur);
             HISTOGRAM_OBSERVE(*m_metrics, fsync_size, iocb->size);
-            LOGINFO("fsync, size {}, lat {}", iocb->size, dur);
+            LOGTRACE("fsync, size {}, lat {}", iocb->size, dur);
             break;
 
         default:

--- a/src/include/iomgr/io_device.hpp
+++ b/src/include/iomgr/io_device.hpp
@@ -20,6 +20,30 @@ struct IODeviceThreadContext {
     virtual ~IODeviceThreadContext() = default;
 };
 
+class IODeviceMetrics : public sisl::MetricsGroup {
+public:
+    IODeviceMetrics(std::string devname) : sisl::MetricsGroup("IODeviceMetrics", devname) {
+
+        REGISTER_HISTOGRAM(read_size, "Read IO Size", "io_size", {"op", "read"}, HistogramBucketsType(OpSizeBuckets));
+        REGISTER_HISTOGRAM(write_size, "Write IO size", "io_size", {"op", "write"},
+                           HistogramBucketsType(OpSizeBuckets));
+        REGISTER_HISTOGRAM(fsync_size, "Fsync IO size", "io_size", {"op", "fsync"},
+                           HistogramBucketsType(OpSizeBuckets));
+        // FixMe: The OpLatecyBuckets might not friendly for HDD
+        REGISTER_HISTOGRAM(read_lat, "Read IO Lat", "io_lat_us", {"op", "read"}, HistogramBucketsType(OpLatecyBuckets));
+        REGISTER_HISTOGRAM(write_lat, "Write IO Lat", "io_lat_us", {"op", "write"},
+                           HistogramBucketsType(OpLatecyBuckets));
+        REGISTER_HISTOGRAM(fsync_lat, "Fsync IO Lat", "io_lat_us", {"op", "fsync"},
+                           HistogramBucketsType(OpLatecyBuckets));
+        register_me_to_farm();
+    }
+    IODeviceMetrics(const IODeviceMetrics&) = delete;
+    IODeviceMetrics(IODeviceMetrics&&) noexcept = delete;
+    IODeviceMetrics& operator=(const IODeviceMetrics&) = delete;
+    IODeviceMetrics& operator=(IODeviceMetrics&&) noexcept = delete;
+    ~IODeviceMetrics() { deregister_me_from_farm(); }
+};
+
 class IODevice {
 public:
     IODevice(const int pri, const thread_specifier scope);
@@ -49,6 +73,7 @@ public:
 private:
     thread_specifier thread_scope{reactor_regex::all_io};
     int pri{1};
+    std::unique_ptr< IODeviceMetrics > m_metrics;
 
 public:
     int fd() const { return std::get< int >(dev); }
@@ -70,6 +95,31 @@ public:
     void clear();
     DriveInterface* drive_interface();
 
+    void observe_metrics(drive_iocb* iocb) {
+        if (!m_metrics.get()) { return; }
+        auto dur = get_elapsed_time_us(iocb->op_start_time);
+        switch (iocb->op_type) {
+        case DriveOpType::WRITE:
+            HISTOGRAM_OBSERVE(*m_metrics, write_lat, dur);
+            HISTOGRAM_OBSERVE(*m_metrics.get(), write_size, iocb->size);
+            LOGINFOMOD(iomgr, "fsync, size {}, lat {}", iocb->size, dur);
+            break;
+        case DriveOpType::READ:
+            HISTOGRAM_OBSERVE(*m_metrics, read_lat, dur);
+            HISTOGRAM_OBSERVE(*m_metrics, read_size, iocb->size);
+            LOGINFOMOD(iomgr, "fsync, size {}, lat {}", iocb->size, dur);
+            break;
+        case DriveOpType::FSYNC:
+            HISTOGRAM_OBSERVE(*m_metrics, fsync_lat, dur);
+            HISTOGRAM_OBSERVE(*m_metrics, fsync_size, iocb->size);
+            LOGINFOMOD(iomgr, "fsync, size {}, lat {}", iocb->size, dur);
+            break;
+
+        default:
+            break;
+        }
+    }
+
     void decrement_pending(int32_t count = 1) {
         if ((post_add_remove_cb != nullptr) && thread_op_pending_count.decrement_testz(count)) {
             post_add_remove_cb(this);
@@ -82,7 +132,10 @@ public:
         }
     }
 
+    void enable_metrics(std::string group_name) { m_metrics = std::make_unique< IODeviceMetrics >(group_name); }
+
     void close() {
+        m_metrics.release();
         if (!is_spdk_dev()) { ::close(fd()); }
     }
 };

--- a/src/include/iomgr/io_device.hpp
+++ b/src/include/iomgr/io_device.hpp
@@ -101,18 +101,18 @@ public:
         switch (iocb->op_type) {
         case DriveOpType::WRITE:
             HISTOGRAM_OBSERVE(*m_metrics, write_lat, dur);
-            HISTOGRAM_OBSERVE(*m_metrics.get(), write_size, iocb->size);
-            LOGINFOMOD(iomgr, "fsync, size {}, lat {}", iocb->size, dur);
+            HISTOGRAM_OBSERVE(*m_metrics, write_size, iocb->size);
+            LOGINFO("write, size {}, lat {}", iocb->size, dur);
             break;
         case DriveOpType::READ:
             HISTOGRAM_OBSERVE(*m_metrics, read_lat, dur);
             HISTOGRAM_OBSERVE(*m_metrics, read_size, iocb->size);
-            LOGINFOMOD(iomgr, "fsync, size {}, lat {}", iocb->size, dur);
+            LOGINFO("read, size {}, lat {}", iocb->size, dur);
             break;
         case DriveOpType::FSYNC:
             HISTOGRAM_OBSERVE(*m_metrics, fsync_lat, dur);
             HISTOGRAM_OBSERVE(*m_metrics, fsync_size, iocb->size);
-            LOGINFOMOD(iomgr, "fsync, size {}, lat {}", iocb->size, dur);
+            LOGINFO("fsync, size {}, lat {}", iocb->size, dur);
             break;
 
         default:

--- a/src/lib/iomgr.cpp
+++ b/src/lib/iomgr.cpp
@@ -69,7 +69,7 @@ SISL_OPTION_GROUP(iomgr,
                   (hdd_streams, "", "hdd_streams", "Number of streams for hdd - overridden value",
                    ::cxxopts::value< uint32_t >()->default_value("64"), "count"))
 
-//SISL v11 change
+// SISL v11 change
 SISL_LOGGING_DEF(iomgr)
 
 namespace iomgr {

--- a/src/test/io_examiner/io_job.hpp
+++ b/src/test/io_examiner/io_job.hpp
@@ -269,6 +269,10 @@ private:
         std::uniform_int_distribution< uint64_t > lba_random{0, vinfo->m_max_vol_blks - max_blks - 1};
         // nlbas: [1, max_blks]
         std::uniform_int_distribution< uint32_t > nlbas_random{1, max_blks};
+        if (m_cfg.io_blk_size && *m_cfg.io_blk_size !=0 ) {
+	    auto nblks = *m_cfg.io_blk_size / vinfo->m_page_size;
+            nlbas_random = std::uniform_int_distribution< uint32_t >(nblks, nblks);
+        }
 
         // we won't be writing more then 128 blocks in one io
         uint32_t attempt{1};

--- a/src/test/io_examiner/io_job.hpp
+++ b/src/test/io_examiner/io_job.hpp
@@ -51,7 +51,7 @@ public:
     bool pre_init_verify{true};
 
     verify_type_t verify_type{verify_type_t::csum}; // What type of verification on every reads
-    load_type_t load_type{load_type_t::random};     // IO type (random, sequential, same)
+    load_type_t load_type{load_type_t::sequential};     // IO type (random, sequential, same)
     buf_pattern_t buf_pattern{buf_pattern_t::lbas}; // Buffer pattern to read/write verify (fill with lba, random)
     std::optional< uint32_t > io_blk_size;          // If not provided, use random blk_size, else use this blksize
 
@@ -164,7 +164,7 @@ public:
     IOJob& operator=(IOJob&&) noexcept = delete;
 
     void run_one_iteration() override {
-        RELEASE_ASSERT_GE(m_cfg.qdepth, iomanager.num_workers());
+        //RELEASE_ASSERT_GE(m_cfg.qdepth, iomanager.num_workers());
 
         while (m_outstanding_ios.load(std::memory_order_acquire) < (int64_t)m_cfg.qdepth) {
             switch (pick_io_type()) {

--- a/src/test/test_io_job.cpp
+++ b/src/test/test_io_job.cpp
@@ -24,6 +24,10 @@ SISL_OPTION_GROUP(test_io,
                    "seconds"),
                   (num_threads, "", "num_threads", "num_threads - default 2 for spdk and 8 for non-spdk",
                    ::cxxopts::value< uint32_t >()->default_value("8"), "number"),
+                  (blk_size, "", "blk_size", "blk size in KB for IO",
+                   ::cxxopts::value< uint32_t >()->default_value("4"), "number"),
+                  (qdepth, "", "qdepth", "qdepth for IO",
+                   ::cxxopts::value< uint32_t >()->default_value("8"), "number"),
                   (device_list, "", "device_list", "List of device paths",
                    ::cxxopts::value< std::vector< std::string > >(), "path [...]"),
                   (device_size, "", "device_size", "size of devices to do IO on",
@@ -48,16 +52,18 @@ TEST(IOMgrTest, basic_io_test) {
             LOGINFO("Device {} doesn't exists, creating a file for size {}", dev, dev_size);
             const auto fd{::open(dev.c_str(), O_RDWR | O_CREAT, 0666)};
             assert(fd > 0);
+            std::filesystem::resize_file(file_path, dev_size);
             ::close(fd);
         }
-        std::filesystem::resize_file(file_path, dev_size);
         examiner->add_device(dev, O_RDWR);
     }
 
     IOJobCfg cfg;
     cfg.max_disk_capacity = dev_size;
     cfg.run_time = SISL_OPTIONS["run_time"].as< uint32_t >();
-    cfg.io_dist = {{io_type_t::write, 50}, {io_type_t::read, 50}};
+    cfg.io_dist = {{io_type_t::write, 100}, {io_type_t::read, 0}};
+    cfg.io_blk_size = SISL_OPTIONS["blk_size"].as< uint32_t >()*1024;
+    cfg.qdepth = SISL_OPTIONS["qdepth"].as< uint32_t >();
 
     IOJob job(examiner, cfg);
     job.start_job(wait_till_t::completion);

--- a/src/test/test_io_job.cpp
+++ b/src/test/test_io_job.cpp
@@ -25,9 +25,11 @@ SISL_OPTION_GROUP(test_io,
                   (num_threads, "", "num_threads", "num_threads - default 2 for spdk and 8 for non-spdk",
                    ::cxxopts::value< uint32_t >()->default_value("8"), "number"),
                   (blk_size, "", "blk_size", "blk size in KB for IO",
-                   ::cxxopts::value< uint32_t >()->default_value("4"), "number"),
+                   ::cxxopts::value< uint32_t >()->default_value("0"), "number"),
                   (qdepth, "", "qdepth", "qdepth for IO",
                    ::cxxopts::value< uint32_t >()->default_value("8"), "number"),
+                  (load_type, "", "load_type", "io_type for IO, 0 - random, 1 - same, 2 - sequential",
+                   ::cxxopts::value< uint32_t >()->default_value("0"), "number"),
                   (device_list, "", "device_list", "List of device paths",
                    ::cxxopts::value< std::vector< std::string > >(), "path [...]"),
                   (device_size, "", "device_size", "size of devices to do IO on",
@@ -62,6 +64,7 @@ TEST(IOMgrTest, basic_io_test) {
     cfg.max_disk_capacity = dev_size;
     cfg.run_time = SISL_OPTIONS["run_time"].as< uint32_t >();
     cfg.io_dist = {{io_type_t::write, 100}, {io_type_t::read, 0}};
+    cfg.load_type = (load_type_t)SISL_OPTIONS["load_type"].as< uint32_t >();
     cfg.io_blk_size = SISL_OPTIONS["blk_size"].as< uint32_t >()*1024;
     cfg.qdepth = SISL_OPTIONS["qdepth"].as< uint32_t >();
 


### PR DESCRIPTION
Interfaces are opt-in as the observe_metrics need to be called from interface.