### PR TITLE
Ensure m_in_flight_ios is decremented after successfully retrieving a CQE.

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -9,7 +9,7 @@ required_conan_version = ">=1.60.0"
 
 class IOMgrConan(ConanFile):
     name = "iomgr"
-    version = "11.4.1"
+    version = "11.4.2"
 
     homepage = "https://github.com/eBay/IOManager"
     description = "Asynchronous event manager"

--- a/src/lib/interfaces/uring_drive_interface.cpp
+++ b/src/lib/interfaces/uring_drive_interface.cpp
@@ -509,7 +509,6 @@ void UringDriveInterface::handle_completions() {
                 iocb->update_iovs_on_partial_result();
                 // retry I/O with remaining unset data;
                 t_uring_ch->m_iocb_waitq.push(iocb);
-                --(t_uring_ch->m_in_flight_ios);
             }
         } else {
             LOGERRORMOD(iomgr, "Error in completion of io, iocb={}, result={}, retry={}", (void*)iocb, iocb->result,
@@ -525,13 +524,12 @@ void UringDriveInterface::handle_completions() {
                 t_uring_ch->m_iocb_waitq.push(iocb);
             }
         }
+        --(t_uring_ch->m_in_flight_ios);
         t_uring_ch->drain_waitq();
     } while (true);
 }
 
 void UringDriveInterface::complete_io(drive_iocb* iocb) {
-    --(t_uring_ch->m_in_flight_ios);
-
 #ifdef _PRERELEASE
     if (DriveInterface::inject_delay_if_needed(iocb, [this](drive_iocb* iocb) { complete_io(iocb); })) { return; }
 #endif


### PR DESCRIPTION
This change prevents m_in_flight_ios from exceeding the actual incomplete IO count, which may block new IO submissions when it incorrectly larger than the uring queue depth.