### PR TITLE
SDSTOR-22330 Pass exp_count to timer callback instead of looping

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -9,7 +9,7 @@ required_conan_version = ">=1.60.0"
 
 class IOMgrConan(ConanFile):
     name = "iomgr"
-    version = "12.0.2"
+    version = "12.0.3"
 
     homepage = "https://github.com/eBay/IOManager"
     description = "Asynchronous event manager"

--- a/src/include/iomgr/iomgr.hpp
+++ b/src/include/iomgr/iomgr.hpp
@@ -284,6 +284,31 @@ public:
                                          timer_callback_t&& timer_fn);
     timer_handle_t schedule_global_timer(uint64_t nanos_after, bool recurring, void* cookie, reactor_regex r,
                                          timer_callback_t&& timer_fn, bool wait_to_schedule = false);
+
+    // Overloads for legacy void(void*) callbacks: wrap to call fn N times (once per expiration).
+    // SFINAE excludes callables already convertible to timer_callback_t (e.g. std::bind results,
+    // which std::bind makes callable with extra args and thus convertible to the 2-param type).
+    template < typename Fn,
+               std::enable_if_t< !std::is_convertible_v< std::decay_t< Fn >, timer_callback_t >, int > = 0 >
+    timer_handle_t schedule_thread_timer(uint64_t nanos_after, bool recurring, void* cookie, Fn&& timer_fn) {
+        return schedule_thread_timer(nanos_after, recurring, cookie,
+                                     timer_callback_t{[fn = std::forward< Fn >(timer_fn)](void* ctx,
+                                                                                           uint64_t exp_count) mutable {
+                                         for (uint64_t i{0}; i < exp_count; ++i) { fn(ctx); }
+                                     }});
+    }
+
+    template < typename Fn,
+               std::enable_if_t< !std::is_convertible_v< std::decay_t< Fn >, timer_callback_t >, int > = 0 >
+    timer_handle_t schedule_global_timer(uint64_t nanos_after, bool recurring, void* cookie, reactor_regex r,
+                                         Fn&& timer_fn, bool wait_to_schedule = false) {
+        return schedule_global_timer(nanos_after, recurring, cookie, r,
+                                     timer_callback_t{[fn = std::forward< Fn >(timer_fn)](void* ctx,
+                                                                                           uint64_t exp_count) mutable {
+                                         for (uint64_t i{0}; i < exp_count; ++i) { fn(ctx); }
+                                     }},
+                                     wait_to_schedule);
+    }
     void cancel_timer(timer_handle_t thdl, bool wait_to_cancel = false);
     void set_poll_interval(const int interval);
     int get_poll_interval() const;

--- a/src/include/iomgr/iomgr_timer.hpp
+++ b/src/include/iomgr/iomgr_timer.hpp
@@ -23,7 +23,7 @@
 
 struct spdk_poller;
 namespace iomgr {
-typedef std::function< void(void*) > timer_callback_t;
+typedef std::function< void(void*, uint64_t) > timer_callback_t;
 
 class timer;
 struct timer_info {
@@ -184,7 +184,7 @@ public:
 
 private:
     std::shared_ptr< IODevice > setup_timer_fd(bool is_recurring, bool wait_to_setup = false);
-    void on_timer_armed(IODevice* iodev);
+    void on_timer_armed(IODevice* iodev, uint64_t exp_count);
 
 private:
     std::shared_ptr< IODevice > m_common_timer_io_dev;                // fd_info for the common timer fd

--- a/src/lib/iomgr_timer.cpp
+++ b/src/lib/iomgr_timer.cpp
@@ -143,13 +143,13 @@ void timer_epoll::on_timer_fd_notification(IODevice* iodev) {
         return; // Nothing is expired. TODO: Update some spurious counter
     }
 
-    // Call the corresponding timer that timer is armed for number of times it has expired
-    for (uint64_t i{0}; i < exp_count; ++i) {
-        ((timer_epoll*)iodev->tinfo->parent_timer)->on_timer_armed(iodev);
+    if (exp_count > 1) {
+        LOGWARN("Timer fd={} expired {} times without being processed, invoking callback once", iodev->fd(), exp_count);
     }
+    ((timer_epoll*)iodev->tinfo->parent_timer)->on_timer_armed(iodev, exp_count);
 }
 
-void timer_epoll::on_timer_armed(IODevice* iodev) {
+void timer_epoll::on_timer_armed(IODevice* iodev, uint64_t exp_count) {
     if (iodev == m_common_timer_io_dev.get()) {
         // This is a non-recurring timer, loop in all timers in heap and call which are expired
         LOCK_IF_GLOBAL();
@@ -159,7 +159,7 @@ void timer_epoll::on_timer_armed(IODevice* iodev) {
             if (tinfo.expiry_time <= time_now) {
                 m_timer_list.pop();
                 UNLOCK_IF_GLOBAL();
-                tinfo.cb(tinfo.context);
+                tinfo.cb(tinfo.context, 1);
                 LOCK_IF_GLOBAL();
             } else {
                 break;
@@ -167,7 +167,7 @@ void timer_epoll::on_timer_armed(IODevice* iodev) {
         }
         UNLOCK_IF_GLOBAL();
     } else {
-        if (!m_stop_pending) { iodev->tinfo->cb(iodev->tinfo->context); }
+        if (!m_stop_pending) { iodev->tinfo->cb(iodev->tinfo->context, exp_count); }
     }
 }
 
@@ -324,7 +324,7 @@ bool spdk_thread_timer_info::call_timer_cb_once() {
     if (!st_info->is_multi_threaded ||
         st_info->cur_term_num.compare_exchange_strong(cur_term_num, term_num, std::memory_order_acq_rel)) {
         ++(iomanager.this_thread_metrics().timer_wakeup_count);
-        st_info->cb(st_info->context);
+        st_info->cb(st_info->context, 1);
         ret = true;
     }
     // NOTE: Do not access this pointer or tinfo from this point, as once callback is called, it could
@@ -344,7 +344,7 @@ void timer_spdk::check_and_call_expired_timers() {
         if (tinfo.expiry_time <= time_now) {
             m_timer_list.pop();
             UNLOCK_IF_GLOBAL();
-            tinfo.cb(tinfo.context);
+            tinfo.cb(tinfo.context, 1);
             LOCK_IF_GLOBAL();
         } else {
             break;

--- a/src/test/test_timer.cpp
+++ b/src/test/test_timer.cpp
@@ -193,6 +193,63 @@ TEST_F(TimerTest, global_recurring_timer) {
     wait_for_all_timers();
 }
 
+// Tests for 2-param void(void*, uint64_t) callbacks that receive exp_count directly.
+TEST_F(TimerTest, thread_timer_2param_cb) {
+    std::mutex mtx;
+    std::condition_variable cv;
+    std::atomic< uint64_t > total_exp_count{0};
+    std::atomic< int > call_count{0};
+    constexpr int target_calls{5};
+
+    // Schedule, run, and cancel all on the same IO fiber to avoid cross-thread cancel issues.
+    timer_handle_t hdl;
+    io_fiber_t timer_fiber;
+    iomanager.run_on(true /* wait */, reactor_regex::random_worker, [&]() {
+        timer_fiber = iomanager.iofiber_self();
+        hdl = iomanager.schedule_thread_timer(5 * 1000 * 1000 /* 5ms */, true /* recurring */, nullptr,
+                                              [&](void*, uint64_t exp_count) {
+                                                  EXPECT_GE(exp_count, 1u);
+                                                  total_exp_count.fetch_add(exp_count, std::memory_order_relaxed);
+                                                  if (++call_count >= target_calls) { cv.notify_one(); }
+                                              });
+    });
+
+    {
+        std::unique_lock< std::mutex > lk{mtx};
+        cv.wait_for(lk, 2s, [&] { return call_count.load() >= target_calls; });
+    }
+    EXPECT_GE(call_count.load(), target_calls);
+    EXPECT_GE(total_exp_count.load(), static_cast< uint64_t >(target_calls));
+
+    // Cancel on the owning fiber.
+    iomanager.run_on(true /* wait */, timer_fiber, [&]() { iomanager.cancel_timer(hdl, false); });
+}
+
+TEST_F(TimerTest, global_timer_2param_cb) {
+    std::mutex mtx;
+    std::condition_variable cv;
+    std::atomic< uint64_t > total_exp_count{0};
+    std::atomic< int > call_count{0};
+    constexpr int target_calls{5};
+
+    auto hdl = iomanager.schedule_global_timer(5 * 1000 * 1000 /* 5ms */, true /* recurring */, nullptr,
+                                               reactor_regex::all_worker,
+                                               [&](void*, uint64_t exp_count) {
+                                                   EXPECT_GE(exp_count, 1u);
+                                                   total_exp_count.fetch_add(exp_count, std::memory_order_relaxed);
+                                                   if (++call_count >= target_calls) { cv.notify_one(); }
+                                               },
+                                               true /* wait */);
+
+    {
+        std::unique_lock< std::mutex > lk{mtx};
+        cv.wait_for(lk, 2s, [&] { return call_count.load() >= target_calls; });
+    }
+    EXPECT_GE(call_count.load(), target_calls);
+    EXPECT_GE(total_exp_count.load(), static_cast< uint64_t >(target_calls));
+    iomanager.cancel_timer(hdl, true /* wait */);
+}
+
 /* NOTE: Make sure this is the last test case, so that iomanager stop is running in parallel to timer test */
 TEST_F(TimerTest, timer_parallel_to_shutdown) {
     std::random_device rd{};


### PR DESCRIPTION
Recurring timer callbacks now receive the timerfd expiration count so they can decide whether to run once or N times. Add backward-compat overloads that preserve old loop-N-times behavior for void(void*) callers.

Add tests for void(void*, uint64_t) thread and global timer callbacks.