### PR TITLE
SDSTOR-22772: Fix double-close of timerfd in timer_epoll destructor and raise fd limit in timer tests

### DIFF
--- a/src/lib/iomgr_timer.cpp
+++ b/src/lib/iomgr_timer.cpp
@@ -56,18 +56,15 @@ timer_epoll::~timer_epoll() {
 void timer_epoll::stop() {
     // Remove all timers in the non-recurring timer list
     while (!m_timer_list.empty()) {
-        // auto& tinfo = m_timer_list.top(); // TODO: Check if we need to make upcall that timer is cancelled
         m_timer_list.pop();
     }
-    // Now close the common timer
+    // remove_io_device with wait=true calls post_remove -> iodev->close() which closes the fd;
+    // do NOT call close(iodev->fd()) afterwards or the fd is double-closed.
     if (m_common_timer_io_dev && (m_common_timer_io_dev->fd() != -1)) {
         iomanager.generic_interface()->remove_io_device(m_common_timer_io_dev, true /* wait */);
-        close(m_common_timer_io_dev->fd());
     }
-    // Now iterate over recurring timer list and remove them
     for (auto& iodev : m_recurring_timer_iodevs) {
         iomanager.generic_interface()->remove_io_device(iodev, true /* wait */);
-        close(iodev->fd());
     }
     m_stopped = true;
 }

--- a/src/test/test_timer.cpp
+++ b/src/test/test_timer.cpp
@@ -3,6 +3,7 @@
 #include <memory>
 #include <mutex>
 #include <random>
+#include <sys/resource.h>
 #include <vector>
 
 #include <gtest/gtest.h>
@@ -67,6 +68,15 @@ static bool g_need_time_check{false};
 static std::vector< timer_handle_t > g_thdls;
 
 void glob_setup() {
+    // Each recurring timer holds its own timerfd; raise the soft limit so 1000 concurrent
+    // timers don't exhaust the default ulimit -n (1024) on Linux CI runners.
+    struct rlimit rl;
+    getrlimit(RLIMIT_NOFILE, &rl);
+    rl.rlim_cur = std::min(rl.rlim_max, static_cast< rlim_t >(65536));
+    if (setrlimit(RLIMIT_NOFILE, &rl) != 0) {
+        LOGWARN("Failed to raise RLIMIT_NOFILE to {}: {}", rl.rlim_cur, strerror(errno));
+    }
+
     g_is_spdk = SISL_OPTIONS["spdk"].as< bool >();
     g_io_threads = SISL_OPTIONS["io_threads"].as< uint32_t >();
     if ((SISL_OPTIONS.count("io_threads") == 0) && g_is_spdk) { g_io_threads = 2; }


### PR DESCRIPTION
`remove_io_device(iodev, true /* wait */)` already closes the underlying fd via `post_remove -> iodev->close()`; the subsequent `close(iodev->fd())` calls in the destructor were double-closing the same fd, which ASAN reports as an error.  Remove the redundant close() calls for both the common timer and all recurring timer iodevs.

Each recurring timer holds its own timerfd, so the 1000-timer stress test can exhaust the default ulimit -n (1024) on Linux CI runners before the double-close even surfaces.  Raise the soft RLIMIT_NOFILE to 65536 (bounded by the hard limit) in SetUpTestSuite so the test has enough fds regardless of system defaults.